### PR TITLE
Small refactoring of Frontend tests with HMPP E2E tests

### DIFF
--- a/plugins/kotlin/gradle/gradle-java/tests/test/org/jetbrains/kotlin/gradle/HierarchicalMultiplatformProjectImportingTest.kt
+++ b/plugins/kotlin/gradle/gradle-java/tests/test/org/jetbrains/kotlin/gradle/HierarchicalMultiplatformProjectImportingTest.kt
@@ -1,0 +1,1348 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+package org.jetbrains.kotlin.gradle.idea.importing
+
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.externalSystem.importing.ImportSpec
+import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.DependencyScope
+import com.intellij.openapi.util.SystemInfo
+import org.jetbrains.jps.model.java.JavaResourceRootType
+import org.jetbrains.jps.model.java.JavaSourceRootType
+import org.jetbrains.kotlin.checkers.utils.clearTextFromDiagnosticMarkup
+import org.jetbrains.kotlin.config.ResourceKotlinRootType
+import org.jetbrains.kotlin.config.SourceKotlinRootType
+import org.jetbrains.kotlin.config.TestResourceKotlinRootType
+import org.jetbrains.kotlin.config.TestSourceKotlinRootType
+import org.jetbrains.kotlin.idea.codeInsight.gradle.GradleKotlinTestUtils.KotlinVersion
+import org.jetbrains.kotlin.idea.codeInsight.gradle.MultiplePluginVersionGradleImportingTestCase
+import org.jetbrains.kotlin.idea.codeInsight.gradle.compareTo
+import org.jetbrains.kotlin.idea.codeInsight.gradle.kotlinPluginVersionMatches
+import org.jetbrains.kotlin.idea.codeInsight.gradle.parseKotlinVersion
+import org.jetbrains.kotlin.idea.gradleTooling.OrphanSourceSetsImportingDiagnostic
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.platform.js.JsPlatforms
+import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
+import org.jetbrains.kotlin.platform.konan.NativePlatforms
+import org.jetbrains.plugins.gradle.internal.daemon.GradleDaemonServices
+import org.jetbrains.plugins.gradle.tooling.annotation.PluginTargetVersions
+import org.junit.After
+import org.junit.AssumptionViolatedException
+import org.junit.Test
+import java.io.PrintStream
+
+class HierarchicalMultiplatformProjectImportingTest : MultiplePluginVersionGradleImportingTestCase() {
+
+    private var isSdkCreationCheckerSuppressed = false
+
+    @After
+    fun after() {
+        GradleDaemonServices.stopDaemons() // Workaround until KTIJ-19669 fixed
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.3.30+")
+    fun testImportHMPPFlag() {
+        configureByFiles()
+        importProject()
+
+        checkProjectStructure(
+            exhaustiveModuleList = false,
+            exhaustiveSourceSourceRootList = false,
+            exhaustiveDependencyList = false
+        ) {
+            allModules {
+                isHMPP(true)
+                assertNoDependencyInBuildClasses()
+            }
+            module("my-app.commonMain")
+            module("my-app.jvmAndJsMain")
+        }
+        //checkHighligthingOnAllModules()
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.3.30+")
+    fun testImportIntermediateModules() {
+        configureByFiles()
+        importProject()
+
+        checkProjectStructure {
+            allModules { assertNoDependencyInBuildClasses() }
+            module("my-app")
+
+            module("my-app.commonMain") {
+                isHMPP(true)
+                targetPlatform(
+                    JsPlatforms.defaultJsPlatform,
+                    JvmPlatforms.jvm6,
+                    NativePlatforms.unspecifiedNativePlatform
+                )
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}",
+                    DependencyScope.COMPILE
+                )
+                sourceFolder("src/commonMain/kotlin", SourceKotlinRootType)
+                sourceFolder("src/commonMain/resources", ResourceKotlinRootType)
+            }
+
+            module("my-app.commonTest") {
+                isHMPP(true)
+                targetPlatform(
+                    JsPlatforms.defaultJsPlatform,
+                    JvmPlatforms.jvm6,
+                    NativePlatforms.unspecifiedNativePlatform
+                )
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-test-annotations-common:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-test-common:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                sourceFolder("src/commonTest/kotlin", TestSourceKotlinRootType)
+                sourceFolder("src/commonTest/resources", TestResourceKotlinRootType)
+            }
+
+            module("my-app.jsMain") {
+                isHMPP(true)
+                targetPlatform(JsPlatforms.defaultJsPlatform)
+                if (!kotlinPluginVersionMatches("1.6.0-dev+")) {
+                    libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}", DependencyScope.COMPILE)
+                }
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinPluginVersionString}",
+                    DependencyScope.COMPILE
+                )
+                moduleDependency("my-app.commonMain", DependencyScope.COMPILE)
+                moduleDependency("my-app.jvmAndJsMain", DependencyScope.COMPILE)
+                moduleDependency("my-app.linuxAndJsMain", DependencyScope.COMPILE)
+                sourceFolder("src/jsMain/kotlin", SourceKotlinRootType)
+                sourceFolder("src/jsMain/resources", ResourceKotlinRootType)
+            }
+
+            module("my-app.jsTest") {
+                isHMPP(true)
+                targetPlatform(JsPlatforms.defaultJsPlatform)
+                if (!kotlinPluginVersionMatches("1.6.0-dev+")) {
+                    libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}", DependencyScope.TEST)
+                }
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+
+                if (!kotlinPluginVersionMatches("1.6.20-dev+")) {
+                    libraryDependency(
+                        "Gradle: org.jetbrains.kotlin:kotlin-test-annotations-common:${kotlinPluginVersionString}",
+                        DependencyScope.TEST
+                    )
+                    libraryDependency(
+                        "Gradle: org.jetbrains.kotlin:kotlin-test-common:${kotlinPluginVersionString}",
+                        DependencyScope.TEST
+                    )
+                }
+
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-test-js:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.TEST)
+                moduleDependency(
+                    "my-app.jsMain",
+                    DependencyScope.RUNTIME
+                )  // Temporary dependency, need to remove after KT-40551 is solved
+                moduleDependency("my-app.jvmAndJsMain", DependencyScope.TEST)
+                moduleDependency("my-app.jvmAndJsTest", DependencyScope.TEST)
+                moduleDependency("my-app.linuxAndJsMain", DependencyScope.TEST)
+                moduleDependency("my-app.linuxAndJsTest", DependencyScope.TEST)
+                sourceFolder("src/jsTest/kotlin", TestSourceKotlinRootType)
+                sourceFolder("src/jsTest/resources", TestResourceKotlinRootType)
+            }
+
+            module("my-app.jvmAndJsMain") {
+                isHMPP(true)
+                targetPlatform(JsPlatforms.defaultJsPlatform, JvmPlatforms.jvm6)
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}",
+                    DependencyScope.COMPILE
+                )
+                moduleDependency("my-app.commonMain", DependencyScope.COMPILE)
+                sourceFolder("src/jvmAndJsMain/kotlin", SourceKotlinRootType)
+                sourceFolder("src/jvmAndJsMain/resources", ResourceKotlinRootType)
+            }
+
+            module("my-app.jvmAndJsTest") {
+                isHMPP(true)
+                targetPlatform(JsPlatforms.defaultJsPlatform, JvmPlatforms.jvm6)
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-test-annotations-common:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-test-common:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.jvmAndJsMain", DependencyScope.TEST)
+                sourceFolder("src/jvmAndJsTest/kotlin", TestSourceKotlinRootType)
+                sourceFolder("src/jvmAndJsTest/resources", TestResourceKotlinRootType)
+            }
+
+            module("my-app.jvmMain") {
+                isHMPP(true)
+                targetPlatform(JvmPlatforms.jvm6)
+
+                if (!kotlinPluginVersionMatches("1.5.30+")) {
+                    libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}", DependencyScope.COMPILE)
+                }
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib:${kotlinPluginVersionString}",
+                    DependencyScope.COMPILE
+                )
+                libraryDependency("Gradle: org.jetbrains:annotations:13.0", DependencyScope.COMPILE)
+                moduleDependency("my-app.commonMain", DependencyScope.COMPILE)
+                moduleDependency("my-app.jvmAndJsMain", DependencyScope.COMPILE)
+                sourceFolder("src/jvmMain/kotlin", JavaSourceRootType.SOURCE)
+                sourceFolder("src/jvmMain/resources", JavaResourceRootType.RESOURCE)
+            }
+
+            module("my-app.jvmTest") {
+                isHMPP(true)
+                targetPlatform(JvmPlatforms.jvm6)
+                libraryDependency(Regex("Gradle: junit:junit:[0-9.]+"), DependencyScope.TEST)
+                libraryDependency("Gradle: org.hamcrest:hamcrest-core:1.3", DependencyScope.TEST)
+
+                if (!kotlinPluginVersionMatches("1.5.30+")) {
+                    libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}", DependencyScope.TEST)
+                }
+
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+
+                if (!kotlinPluginVersionMatches("1.6.20-dev+")) {
+                    libraryDependency(
+                        "Gradle: org.jetbrains.kotlin:kotlin-test-annotations-common:${kotlinPluginVersionString}",
+                        DependencyScope.TEST
+                    )
+                    libraryDependency(
+                        "Gradle: org.jetbrains.kotlin:kotlin-test-common:${kotlinPluginVersionString}",
+                        DependencyScope.TEST
+                    )
+                }
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-test-junit:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-test:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                libraryDependency("Gradle: org.jetbrains:annotations:13.0", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.jvmAndJsMain", DependencyScope.TEST)
+                moduleDependency("my-app.jvmAndJsTest", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.TEST)
+                moduleDependency(
+                    "my-app.jvmMain",
+                    DependencyScope.RUNTIME
+                )  // Temporary dependency, need to remove after KT-40551 is solved
+                sourceFolder("src/jvmTest/kotlin", JavaSourceRootType.TEST_SOURCE)
+                sourceFolder("src/jvmTest/resources", JavaResourceRootType.TEST_RESOURCE)
+            }
+
+            module("my-app.linuxAndJsMain") {
+                isHMPP(true)
+                targetPlatform(JsPlatforms.defaultJsPlatform, NativePlatforms.unspecifiedNativePlatform)
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}",
+                    DependencyScope.COMPILE
+                )
+                moduleDependency("my-app.commonMain", DependencyScope.COMPILE)
+                sourceFolder("src/linuxAndJsMain/kotlin", SourceKotlinRootType)
+                sourceFolder("src/linuxAndJsMain/resources", ResourceKotlinRootType)
+            }
+
+            module("my-app.linuxAndJsTest") {
+                isHMPP(true)
+                targetPlatform(JsPlatforms.defaultJsPlatform, NativePlatforms.unspecifiedNativePlatform)
+                sourceFolder("src/linuxAndJsTest/kotlin", TestSourceKotlinRootType)
+                sourceFolder("src/linuxAndJsTest/resources", TestResourceKotlinRootType)
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-test-annotations-common:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlin:kotlin-test-common:${kotlinPluginVersionString}",
+                    DependencyScope.TEST
+                )
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.linuxAndJsMain", DependencyScope.TEST)
+            }
+
+            module("my-app.linuxX64Main") {
+                isHMPP(true)
+                targetPlatform(NativePlatforms.nativePlatformBySingleTarget(KonanTarget.LINUX_X64))
+
+                if (!kotlinPluginVersionMatches("1.6.0-dev+")) {
+                    libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}", DependencyScope.COMPILE)
+                }
+
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+
+                if (kotlinPluginVersion >= parseKotlinVersion("1.4.0")) {
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - builtin | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - iconv | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - linux | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - posix | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - zlib | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                } else {
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - builtin",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - iconv",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - linux",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - posix",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - zlib",
+                        DependencyScope.PROVIDED
+                    )
+                }
+
+                moduleDependency("my-app.commonMain", DependencyScope.COMPILE)
+                moduleDependency("my-app.linuxAndJsMain", DependencyScope.COMPILE)
+                sourceFolder("src/linuxX64Main/kotlin", SourceKotlinRootType)
+                sourceFolder("src/linuxX64Main/resources", ResourceKotlinRootType)
+            }
+
+            module("my-app.linuxX64Test") {
+                isHMPP(true)
+                targetPlatform(NativePlatforms.nativePlatformBySingleTarget(KonanTarget.LINUX_X64))
+
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+
+                if (!kotlinPluginVersionMatches("1.6.0-dev+")) {
+                    libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinPluginVersionString}", DependencyScope.TEST)
+                }
+
+                if (!kotlinPluginVersionMatches("1.6.20-dev+")) {
+                    libraryDependency(
+                        "Gradle: org.jetbrains.kotlin:kotlin-test-annotations-common:${kotlinPluginVersionString}",
+                        DependencyScope.TEST
+                    )
+                    libraryDependency(
+                        "Gradle: org.jetbrains.kotlin:kotlin-test-common:${kotlinPluginVersionString}",
+                        DependencyScope.TEST
+                    )
+                }
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - builtin( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - iconv( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - linux( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - posix( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - zlib( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.linuxAndJsMain", DependencyScope.TEST)
+                moduleDependency("my-app.linuxAndJsTest", DependencyScope.TEST)
+                moduleDependency("my-app.linuxX64Main", DependencyScope.TEST)
+                sourceFolder("src/linuxX64Test/kotlin", TestSourceKotlinRootType)
+                sourceFolder("src/linuxX64Test/resources", TestResourceKotlinRootType)
+            }
+        }
+    }
+
+    // TODO: Support test for pluginVersion 1.4.0+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.3.30 <=> 1.3.72")
+    fun testJvmWithJavaOnHMPP() {
+        configureByFiles()
+        importProject()
+
+        checkProjectStructure(true, false, true) {
+            allModules { assertNoDependencyInBuildClasses() }
+
+            module("jvm-on-mpp")
+
+            module("jvm-on-mpp.jvm-mod")
+
+            module("jvm-on-mpp.jvm-mod.main") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.COMPILE)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmAndJsMain", DependencyScope.COMPILE)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmMain", DependencyScope.COMPILE)
+            }
+
+            module("jvm-on-mpp.jvm-mod.test") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.COMPILE)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmAndJsMain", DependencyScope.COMPILE)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmMain", DependencyScope.COMPILE)
+                moduleDependency("jvm-on-mpp.jvm-mod.main", DependencyScope.COMPILE)
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a")
+
+            module("jvm-on-mpp.hmpp-mod-a.commonMain")
+
+            module("jvm-on-mpp.hmpp-mod-a.commonTest") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.TEST)
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.jsMain") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.COMPILE)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmAndJsMain", DependencyScope.COMPILE)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.linuxAndJsMain", DependencyScope.COMPILE)
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.jsTest") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonTest", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jsMain", DependencyScope.TEST)
+                moduleDependency(
+                    "jvm-on-mpp.hmpp-mod-a.jsMain",
+                    DependencyScope.RUNTIME
+                ) // Temporary dependency, need to remove after KT-40551 is solved
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmAndJsMain", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmAndJsTest", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.linuxAndJsMain", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.linuxAndJsTest", DependencyScope.TEST)
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.jvmAndJsMain") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.COMPILE)
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.jvmAndJsTest") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonTest", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmAndJsMain", DependencyScope.TEST)
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.jvmMain") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.COMPILE)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmAndJsMain", DependencyScope.COMPILE)
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.jvmTest") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonTest", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmAndJsMain", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmAndJsTest", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.jvmMain", DependencyScope.TEST)
+                moduleDependency(
+                    "jvm-on-mpp.hmpp-mod-a.jvmMain",
+                    DependencyScope.RUNTIME
+                )  // Temporary dependency, need to remove after KT-40551 is solved
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.linuxAndJsMain") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.COMPILE)
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.linuxAndJsTest") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonTest", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.linuxAndJsMain", DependencyScope.TEST)
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.linuxX64Main") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.COMPILE)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.linuxAndJsMain", DependencyScope.COMPILE)
+
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+
+                if (kotlinPluginVersion >= parseKotlinVersion("1.4.0")) {
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - builtin | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - iconv | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - linux | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - posix | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - zlib | linux_x64",
+                        DependencyScope.PROVIDED
+                    )
+                } else {
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - builtin",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - iconv",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - linux",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - posix",
+                        DependencyScope.PROVIDED
+                    )
+                    libraryDependency(
+                        "Kotlin/Native ${kotlinPluginVersionString} - zlib",
+                        DependencyScope.PROVIDED
+                    )
+                }
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.linuxX64Test") {
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonMain", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.commonTest", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.linuxAndJsMain", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.linuxAndJsTest", DependencyScope.TEST)
+                moduleDependency("jvm-on-mpp.hmpp-mod-a.linuxX64Main", DependencyScope.TEST)
+
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - builtin( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - iconv( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - linux( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - posix( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+                libraryDependency(
+                    Regex("Kotlin/Native ${kotlinPluginVersionString} - zlib( \\| linux_x64)?"),
+                    DependencyScope.PROVIDED
+                )
+            }
+
+            module("jvm-on-mpp.hmpp-mod-a.main")
+            module("jvm-on-mpp.hmpp-mod-a.test")
+        }
+    }
+
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.20+")
+    fun testJvmAndAndroidMainCoroutinesDependency() {
+        configureByFiles()
+        createLocalPropertiesSubFileForAndroid()
+        importProject()
+        val highlightingCheck = createHighlightingCheck()
+        checkProjectStructure(false, false, false) {
+            allModules {
+                assertNoDependencyInBuildClasses()
+                highlightingCheck(module)
+            }
+
+            module("project.p1.commonMain") {
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlinx:kotlinx-coroutines-core-metadata:commonMain:1.4.2",
+                    DependencyScope.COMPILE
+                )
+            }
+
+            module("project.p1.jvmAndAndroidMain") {
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlinx:kotlinx-coroutines-core-metadata:commonMain:1.4.2",
+                    DependencyScope.COMPILE
+                )
+
+                if (kotlinPluginVersion < parseKotlinVersion("1.5.20-dev")) {
+                    libraryDependency(
+                        "Gradle: org.jetbrains.kotlinx:kotlinx-coroutines-core-metadata:concurrentMain:1.4.2",
+                        DependencyScope.COMPILE
+                    )
+                }
+
+                libraryDependency(
+                    "Gradle: org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.2",
+                    DependencyScope.COMPILE
+                )
+
+                if (kotlinPluginVersion < parseKotlinVersion("1.4.30")) {
+                    libraryDependency(
+                        "Gradle: org.jetbrains.kotlinx:kotlinx-coroutines-core-metadata:all:1.4.2",
+                        DependencyScope.COMPILE
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.0+")
+    fun testPrecisePlatformsHmpp() {
+        configureByFiles()
+        importProject()
+
+        val jvm = JvmPlatforms.defaultJvmPlatform
+        val anyNative = NativePlatforms.unspecifiedNativePlatform
+        val linux = NativePlatforms.nativePlatformBySingleTarget(KonanTarget.LINUX_X64)
+        val macos = NativePlatforms.nativePlatformBySingleTarget(KonanTarget.MACOS_X64)
+
+        checkProjectStructure(exhaustiveModuleList = true, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = false) {
+            allModules { assertNoDependencyInBuildClasses() }
+            module("my-app") {
+                targetPlatform(jvm)
+            }
+
+            module("my-app.commonMain") { targetPlatform(jvm, anyNative) }
+            module("my-app.commonTest") { targetPlatform(jvm, anyNative) }
+
+            module("my-app.jvmAndLinuxMain") { targetPlatform(jvm, anyNative) }
+            module("my-app.jvmAndLinuxTest") { targetPlatform(jvm, anyNative) }
+
+            module("my-app.jvmMain") { targetPlatform(jvm) }
+            module("my-app.jvmTest") { targetPlatform(jvm) }
+
+            module("my-app.linuxX64Main") { targetPlatform(linux) }
+            module("my-app.linuxX64Test") { targetPlatform(linux) }
+
+            module("my-app.macosX64Main") { targetPlatform(macos) }
+            module("my-app.macosX64Test") { targetPlatform(macos) }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.0+")
+    fun testPrecisePlatformsWithUnrelatedModuleHmpp() {
+        configureByFiles()
+        importProject()
+
+        val jvm = JvmPlatforms.defaultJvmPlatform
+        val anyNative = NativePlatforms.unspecifiedNativePlatform
+        val js = JsPlatforms.defaultJsPlatform
+        val linux = NativePlatforms.nativePlatformBySingleTarget(KonanTarget.LINUX_X64)
+        val macos = NativePlatforms.nativePlatformBySingleTarget(KonanTarget.MACOS_X64)
+
+        checkProjectStructure(exhaustiveModuleList = true, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = false) {
+            allModules { assertNoDependencyInBuildClasses() }
+            // root project
+            module("my-app") {
+                targetPlatform(jvm)
+            }
+
+            module("my-app.commonMain") { targetPlatform(jvm, anyNative) }
+            module("my-app.commonTest") { targetPlatform(jvm, anyNative) }
+
+            module("my-app.jvmAndLinuxMain") { targetPlatform(jvm, anyNative) }
+            module("my-app.jvmAndLinuxTest") { targetPlatform(jvm, anyNative) }
+
+            module("my-app.jvmMain") { targetPlatform(jvm) }
+            module("my-app.jvmTest") { targetPlatform(jvm) }
+
+            module("my-app.linuxX64Main") { targetPlatform(linux) }
+            module("my-app.linuxX64Test") { targetPlatform(linux) }
+
+            module("my-app.macosX64Main") { targetPlatform(macos) }
+            module("my-app.macosX64Test") { targetPlatform(macos) }
+
+
+            // submodule
+            module("my-app.submodule") { targetPlatform(jvm) }
+
+            module("my-app.submodule.commonMain") { targetPlatform(js, jvm) }
+            module("my-app.submodule.commonTest") { targetPlatform(js, jvm) }
+
+            module("my-app.submodule.jvmMain") { targetPlatform(jvm) }
+            module("my-app.submodule.jvmTest") { targetPlatform(jvm) }
+
+            module("my-app.submodule.jsMain") { targetPlatform(js) }
+            module("my-app.submodule.jsTest") { targetPlatform(js) }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.0+")
+    fun testOrphanSourceSet() {
+        configureByFiles()
+        importProject()
+
+        val jvm = JvmPlatforms.defaultJvmPlatform
+        val js = JsPlatforms.defaultJsPlatform
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = false) {
+            allModules { assertNoDependencyInBuildClasses() }
+
+            module("my-app.commonMain") {
+                // must not be (jvm, js, native)
+                targetPlatform(jvm, js)
+            }
+
+            module("my-app.orphan") {
+                targetPlatform(jvm, js)
+            }
+
+            module("my-app") {
+                assertDiagnosticsCount<OrphanSourceSetsImportingDiagnostic>(1)
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.0+")
+    fun testSourceSetIncludedIntoCompilationDirectly() {
+        configureByFiles()
+        importProject()
+
+        val jvm = JvmPlatforms.defaultJvmPlatform
+        val js = JsPlatforms.defaultJsPlatform
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = false) {
+            allModules { assertNoDependencyInBuildClasses() }
+            module("my-app.commonMain") {
+                targetPlatform(jvm, js) // must not be (jvm, js, native)
+            }
+
+            module("my-app.includedIntoJvm") {
+                targetPlatform(jvm) // !
+            }
+
+            module("my-app.includedIntoJvmAndJs") {
+                targetPlatform(jvm, js) // !
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.0+")
+    fun testDefaultSourceSetDependsOnDefaultSourceSet() {
+        configureByFiles()
+        importProject()
+
+        val jvm = JvmPlatforms.defaultJvmPlatform
+        val js = JsPlatforms.defaultJsPlatform
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = false) {
+            allModules { assertNoDependencyInBuildClasses() }
+            module("my-app.commonMain") {
+                targetPlatform(jvm, js) // must not be (jvm, js, native)
+            }
+
+            module("my-app.intermediateBetweenJsAndCommon") {
+                targetPlatform(jvm, js) // must not be (jvm, js, native)
+            }
+
+            module("my-app.jsMain") {
+                targetPlatform(js) // must not be (jvm, js)
+            }
+
+            module("my-app.jvmMain") {
+                targetPlatform(jvm)
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.0+")
+    fun testDefaultSourceSetIncludedIntoAnotherCompilationDirectly() {
+        configureByFiles()
+        importProject()
+
+        val jvm = JvmPlatforms.defaultJvmPlatform
+        val js = JsPlatforms.defaultJsPlatform
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = false) {
+            allModules { assertNoDependencyInBuildClasses() }
+
+            module("my-app.jvmMain") {
+                targetPlatform(jvm) // must not be (jvm, js)
+            }
+
+            module("my-app.jsMain") {
+                targetPlatform(js)
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.0+")
+    fun testSourceSetsWithDependsOnButNotIncludedIntoCompilation() {
+        configureByFiles()
+        importProject()
+
+        val jvm = JvmPlatforms.defaultJvmPlatform
+        val js = JsPlatforms.defaultJsPlatform
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = false) {
+            allModules { assertNoDependencyInBuildClasses() }
+
+            module("my-app") {
+                assertDiagnosticsCount<OrphanSourceSetsImportingDiagnostic>(3)
+            }
+
+            // (jvm, js, native) is highly undesirable
+            module("my-app.danglingOnJvm") {
+                targetPlatform(jvm, js)
+            }
+
+            module("my-app.commonMain") {
+                targetPlatform(jvm, js)
+            }
+
+            module("my-app.danglingOnCommon") {
+                targetPlatform(jvm, js)
+            }
+
+            module("my-app.danglingOnJvmAndJs") {
+                targetPlatform(jvm, js)
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.0+")
+    fun testCustomAddToCompilationPlusDependsOn() {
+        configureByFiles()
+        importProject()
+
+        val jvm = JvmPlatforms.defaultJvmPlatform
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = false) {
+            allModules { assertNoDependencyInBuildClasses() }
+
+            module("my-app.includedIntoJvm") {
+                targetPlatform(jvm) // !
+            }
+
+            module("my-app.pseudoOrphan") {
+                targetPlatform(jvm) // !
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.4.0+")
+    fun testCommonMainIsSingleBackend() {
+        configureByFiles()
+        importProject()
+
+        val macosX64 = NativePlatforms.nativePlatformBySingleTarget(KonanTarget.MACOS_X64)
+        val linuxX64 = NativePlatforms.nativePlatformBySingleTarget(KonanTarget.LINUX_X64)
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = false) {
+            allModules { assertNoDependencyInBuildClasses() }
+
+            module("my-app.commonMain") { targetPlatform(macosX64, linuxX64) }
+            module("my-app.commonTest") { targetPlatform(macosX64, linuxX64) }
+
+            module("my-app.linuxX64Main") { targetPlatform(linuxX64) }
+            module("my-app.linuxX64Test") { targetPlatform(linuxX64) }
+
+            module("my-app.macosX64Test") { targetPlatform(macosX64) }
+            module("my-app.macosX64Main") { targetPlatform(macosX64) }
+        }
+    }
+
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "5.6+", pluginVersion = "1.3.72+")
+    fun testKTIJ1215JvmTestToJvmMainDependency() {
+        configureByFiles()
+        createLocalPropertiesSubFileForAndroid()
+        importProject()
+        checkProjectStructure(
+            exhaustiveModuleList = false,
+            exhaustiveSourceSourceRootList = false,
+            exhaustiveDependencyList = false
+        ) {
+            /* Assert that we do not depend on any classes from the build directory */
+            allModules {
+                isHMPP(true)
+                assertNoDependencyInBuildClasses()
+            }
+            module("project.p2.commonMain")
+            module("project.p2.commonTest")
+            module("project.p2.jvmMain")
+            module("project.p2.jvmTest") {
+                moduleDependency("project.p2.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p2.commonTest", DependencyScope.TEST)
+                moduleDependency("project.p2.jvmMain", DependencyScope.TEST)
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(gradleVersion = "6.1+", pluginVersion = "1.4+")
+    fun testKT46417NativePlatformTestSourceSets() {
+        // Regression in 1.5.0
+        if (kotlinPluginVersion == KotlinVersion(1, 5, 0)) {
+            isSdkCreationCheckerSuppressed = true
+            throw AssumptionViolatedException("1.5.0 is not supported: https://youtrack.jetbrains.com/issue/KT-46417")
+        }
+
+        configureByFiles()
+        importProject()
+
+        checkProjectStructure(false, false, false) {
+            module("project.p2.iosTest") {
+                /* Intra project dependencies */
+                moduleDependency("project.p2.commonTest", DependencyScope.TEST)
+                moduleDependency("project.p2.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p2.iosMain", DependencyScope.TEST)
+
+                /* Dependencies on p1 */
+                moduleDependency("project.p1.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p1.nativeMain", DependencyScope.TEST)
+                moduleDependency("project.p1.iosMain", DependencyScope.TEST)
+
+                assertExhaustiveModuleDependencyList()
+            }
+
+            module("project.p2.iosX64Test") {
+                /* Intra project dependencies */
+                moduleDependency("project.p2.commonTest", DependencyScope.TEST)
+                moduleDependency("project.p2.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p2.iosMain", DependencyScope.TEST)
+                moduleDependency("project.p2.iosX64Main", DependencyScope.TEST)
+                moduleDependency("project.p2.iosTest", DependencyScope.TEST)
+
+                /* Dependencies on p1 */
+                moduleDependency("project.p1.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p1.nativeMain", DependencyScope.TEST)
+                moduleDependency("project.p1.iosMain", DependencyScope.TEST)
+                moduleDependency(
+                    "project.p1.iosX64Main", DependencyScope.TEST,
+                    //https://youtrack.jetbrains.com/issue/KTIJ-11578
+                    isOptional = !SystemInfo.isMac
+                )
+
+                assertExhaustiveModuleDependencyList()
+            }
+
+            module("project.p2.iosArm64Test") {
+                /* Intra project dependencies */
+                moduleDependency("project.p2.commonTest", DependencyScope.TEST)
+                moduleDependency("project.p2.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p2.iosMain", DependencyScope.TEST)
+                moduleDependency("project.p2.iosArm64Main", DependencyScope.TEST)
+                moduleDependency("project.p2.iosTest", DependencyScope.TEST)
+
+                /* Dependencies on p1 */
+                moduleDependency("project.p1.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p1.nativeMain", DependencyScope.TEST)
+                moduleDependency("project.p1.iosMain", DependencyScope.TEST)
+                moduleDependency(
+                    "project.p1.iosArm64Main", DependencyScope.TEST,
+                    //https://youtrack.jetbrains.com/issue/KTIJ-11578
+                    isOptional = !SystemInfo.isMac
+                )
+
+                assertExhaustiveModuleDependencyList()
+            }
+
+
+            module("project.p2.linuxX64Test") {
+                /* Intra project dependencies */
+                moduleDependency("project.p2.commonTest", DependencyScope.TEST)
+                moduleDependency("project.p2.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p2.linuxMain", DependencyScope.TEST)
+                moduleDependency("project.p2.linuxX64Main", DependencyScope.TEST)
+
+
+                /* Dependencies on p1 */
+                moduleDependency("project.p1.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p1.nativeMain", DependencyScope.TEST)
+                moduleDependency("project.p1.linuxMain", DependencyScope.TEST)
+                moduleDependency("project.p1.linuxX64Main", DependencyScope.TEST)
+
+                assertExhaustiveModuleDependencyList()
+            }
+
+            module("project.p2.linuxArm64Test") {
+                /* Intra project dependencies */
+                moduleDependency("project.p2.commonTest", DependencyScope.TEST)
+                moduleDependency("project.p2.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p2.linuxMain", DependencyScope.TEST)
+                moduleDependency("project.p2.linuxArm64Main", DependencyScope.TEST)
+
+                /* Dependencies on p1 */
+                moduleDependency("project.p1.commonMain", DependencyScope.TEST)
+                moduleDependency("project.p1.nativeMain", DependencyScope.TEST)
+                moduleDependency("project.p1.linuxMain", DependencyScope.TEST)
+                moduleDependency("project.p1.linuxArm64Main", DependencyScope.TEST)
+
+                assertExhaustiveModuleDependencyList()
+            }
+
+
+            createHighlightingCheck(
+                testLineMarkers = false,
+                severityLevel = HighlightSeverity.ERROR
+            ).let { highlightingCheck ->
+                ModuleManager.getInstance(myProject).modules.forEach { module ->
+                    // https://youtrack.jetbrains.com/issue/KTIJ-11578
+                    if (module.name.contains("iosArm64") || module.name.contains("iosX64")) {
+                        if (SystemInfo.isMac) {
+                            highlightingCheck(module)
+                        }
+                    } else {
+                        highlightingCheck(module)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(pluginVersion = "1.6.0-dev+")
+    fun testDependencyOnStdlibFromPlatformSourceSets() {
+        configureByFiles()
+        importProject()
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = true) {
+            module("my-app.jvmMain") {
+                moduleDependency("my-app.commonMain", DependencyScope.COMPILE)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib:${kotlinPluginVersionString}", DependencyScope.COMPILE)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinPluginVersionString}", DependencyScope.COMPILE)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinPluginVersionString}", DependencyScope.COMPILE)
+                libraryDependency("Gradle: org.jetbrains:annotations:13.0", DependencyScope.COMPILE)
+                assertExhaustiveDependencyList()
+            }
+
+            module("my-app.jvmTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.RUNTIME)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains:annotations:13.0", DependencyScope.TEST)
+                noLibraryDependency(".*stdlib-common.*")
+                assertExhaustiveDependencyList()
+            }
+
+            module("my-app.jsMain") {
+                moduleDependency("my-app.commonMain", DependencyScope.COMPILE)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinPluginVersionString}", DependencyScope.COMPILE)
+            }
+
+            module("my-app.jsTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.RUNTIME)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinPluginVersionString}", DependencyScope.TEST)
+            }
+
+            module("my-app.linuxX64Main") {
+                moduleDependency("my-app.commonMain", DependencyScope.COMPILE)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - builtin | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - iconv | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - linux | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - posix | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - zlib | linux_x64", DependencyScope.PROVIDED)
+            }
+
+            module("my-app.linuxX64Test") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.linuxX64Main", DependencyScope.TEST)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - builtin | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - iconv | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - linux | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - posix | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - zlib | linux_x64", DependencyScope.PROVIDED)
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(pluginVersion = "1.6.20-dev+")
+    fun testDependencyOnKotlinTestFromPlatformSourceSets() {
+        configureByFiles()
+        importProject()
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = true) {
+            module("my-app.jvmTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.RUNTIME)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains:annotations:13.0", DependencyScope.TEST)
+                libraryDependency("Gradle: junit:junit:4.13.2", DependencyScope.TEST)
+                libraryDependency("Gradle: org.hamcrest:hamcrest-core:1.3", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-test-junit:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-test:${kotlinPluginVersionString}", DependencyScope.TEST)
+            }
+
+            module("my-app.jsTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.RUNTIME)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-test-js:${kotlinPluginVersionString}", DependencyScope.TEST)
+            }
+
+            module("my-app.linuxX64Test") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.linuxX64Main", DependencyScope.TEST)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - builtin | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - iconv | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - linux | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - posix | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - zlib | linux_x64", DependencyScope.PROVIDED)
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(pluginVersion = "1.6.20-dev+")
+    fun testMppLibAndHmppConsumer() {
+        configureByFiles()
+
+        runTaskAndGetErrorOutput("$projectPath/lib", "publish")
+
+        importProject()
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = true) {
+            module("my-app.jvmTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.RUNTIME)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib:${kotlinPluginVersionString}", DependencyScope.TEST)
+                // BAD! HMPP consumer gets dependency on root module of pre-HMPP library in platform-specific source set
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib:1.0", DependencyScope.TEST)
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib-jvm:1.0", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains:annotations:13.0", DependencyScope.TEST)
+            }
+
+            module("my-app.jsTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.RUNTIME)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib-js:1.0", DependencyScope.TEST)
+            }
+
+            module("my-app.linuxX64Test") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.linuxX64Main", DependencyScope.TEST)
+                // BAD! HMPP consumer gets dependency on root module of pre-HMPP library in platform-specific source set
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib:1.0", DependencyScope.TEST)
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib-linuxx64:klib:1.0", DependencyScope.TEST)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - builtin | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - iconv | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - linux | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - posix | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - zlib | linux_x64", DependencyScope.PROVIDED)
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(pluginVersion = "1.6.20-dev+")
+    fun testHmppLibAndHmppConsumer() {
+        configureByFiles()
+
+        runTaskAndGetErrorOutput("$projectPath/lib", "publish")
+
+        importProject()
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = true) {
+            module("my-app.jvmTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.RUNTIME)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib:${kotlinPluginVersionString}", DependencyScope.TEST)
+                // note: HMPP consumers get only platform module from HMPP libraries, as expected
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib-jvm:1.0", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains:annotations:13.0", DependencyScope.TEST)
+            }
+
+            module("my-app.jsTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.RUNTIME)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinPluginVersionString}", DependencyScope.TEST)
+                // note: HMPP consumers get only platform module from HMPP libraries, as expected
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib-js:1.0", DependencyScope.TEST)
+            }
+
+            module("my-app.linuxX64Test") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.linuxX64Main", DependencyScope.TEST)
+                // note: HMPP consumers get only platform module from HMPP libraries, as expected
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib-linuxx64:klib:1.0", DependencyScope.TEST)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - builtin | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - iconv | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - linux | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - posix | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - zlib | linux_x64", DependencyScope.PROVIDED)
+            }
+        }
+    }
+
+    @Test
+    @PluginTargetVersions(pluginVersion = "1.6.20-dev+")
+    fun testHmppLibAndMppConsumer() {
+        configureByFiles()
+
+        runTaskAndGetErrorOutput("$projectPath/lib", "publish")
+
+        importProject()
+
+        checkProjectStructure(exhaustiveModuleList = false, exhaustiveSourceSourceRootList = false, exhaustiveDependencyList = true) {
+            module("my-app.jvmTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.TEST)
+                moduleDependency("my-app.jvmMain", DependencyScope.RUNTIME)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib:${kotlinPluginVersionString}", DependencyScope.TEST)
+                // pre-HMPP consumers get dependency on common module, this is fine because without HMPP platform-specific
+                // source set won't be able to read .kotlin_metadata even
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib:1.0", DependencyScope.TEST)
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib-jvm:1.0", DependencyScope.TEST)
+                libraryDependency("Gradle: org.jetbrains:annotations:13.0", DependencyScope.TEST)
+            }
+
+            module("my-app.jsTest") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.TEST)
+                moduleDependency("my-app.jsMain", DependencyScope.RUNTIME)
+                libraryDependency("Gradle: org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinPluginVersionString}", DependencyScope.TEST)
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib-js:1.0", DependencyScope.TEST)
+            }
+
+            module("my-app.linuxX64Test") {
+                moduleDependency("my-app.commonTest", DependencyScope.TEST)
+                moduleDependency("my-app.commonMain", DependencyScope.TEST)
+                moduleDependency("my-app.linuxX64Main", DependencyScope.TEST)
+                // pre-HMPP consumers get dependency on common module, this is fine because without HMPP platform-specific
+                // source set won't be able to read .kotlin_metadata even
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib:1.0", DependencyScope.TEST)
+                libraryDependency("Gradle: com.h0tk3y.mpp.demo:lib-linuxx64:klib:1.0", DependencyScope.TEST)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - builtin | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - iconv | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - linux | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - posix | linux_x64", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - stdlib", DependencyScope.PROVIDED)
+                libraryDependency("Kotlin/Native ${kotlinPluginVersionString} - zlib | linux_x64", DependencyScope.PROVIDED)
+            }
+        }
+    }
+
+    override fun createImportSpec(): ImportSpec {
+        return ImportSpecBuilder(super.createImportSpec())
+            .createDirectoriesForEmptyContentRoots()
+            .build()
+    }
+
+    override fun importProject() {
+        val isUseQualifiedModuleNames = currentExternalProjectSettings.isUseQualifiedModuleNames
+        currentExternalProjectSettings.isUseQualifiedModuleNames = true
+        try {
+            super.importProject()
+        } finally {
+            currentExternalProjectSettings.isUseQualifiedModuleNames = isUseQualifiedModuleNames
+        }
+    }
+
+    override fun clearTextFromMarkup(text: String): String {
+        return clearTextFromDiagnosticMarkup(text)
+    }
+
+
+    override fun printOutput(stream: PrintStream, text: String) = stream.println(text)
+
+    override fun testDataDirName(): String {
+        return "hierarchicalMultiplatformImport"
+    }
+}

--- a/plugins/kotlin/gradle/gradle-java/tests/test/org/jetbrains/kotlin/gradle/HmppImportAndHighlightingTests.kt
+++ b/plugins/kotlin/gradle/gradle-java/tests/test/org/jetbrains/kotlin/gradle/HmppImportAndHighlightingTests.kt
@@ -366,6 +366,20 @@ abstract class HmppImportAndHighlightingTests : MultiplePluginVersionGradleImpor
                     targetPlatform(allNative, js, jvm)
                     moduleDependency("multimod-hmpp.top-mpp.commonMain", DependencyScope.TEST)
                 }
+                module("multimod-hmpp.top-mpp.common") {
+                    targetPlatform(allNative, js, jvm)
+                    moduleDependency("multimod-hmpp.api-jvm.main", DependencyScope.COMPILE)
+                }
+                module("multimod-hmpp.top-mpp.jvmLibrary") {
+                    targetPlatform(allNative, js, jvm)
+                    moduleDependency("multimod-hmpp.top-mpp.commonMain", DependencyScope.COMPILE)
+                }
+                module("multimod-hmpp.top-mpp.jvm") {
+                    targetPlatform(allNative, js, jvm)
+                    moduleDependency("multimod-hmpp.api-jvm.main", DependencyScope.COMPILE)
+                    moduleDependency("multimod-hmpp.top-mpp.common", DependencyScope.COMPILE)
+                    moduleDependency("multimod-hmpp.bottom-mpp.commonMain", DependencyScope.COMPILE)
+                }
                 module("multimod-hmpp.top-mpp.dummyiOSMain") {
                     targetPlatform(iosX64)
                     moduleDependency("multimod-hmpp.top-mpp.commonMain", DependencyScope.COMPILE)
@@ -481,6 +495,14 @@ abstract class HmppImportAndHighlightingTests : MultiplePluginVersionGradleImpor
         @Test
         @PluginTargetVersions(pluginVersion = "1.5.30+")
         fun testKt46625SupportedAndUnsupportedPlatform() {
+            configureByFiles()
+            importProject()
+            checkHighligthingOnAllModules()
+        }
+
+        @Test
+        @PluginTargetVersions(pluginVersion = "1.4.20")
+        fun testKt41218SupportedAndUnsupportedPlatform(){
             configureByFiles()
             importProject()
             checkHighligthingOnAllModules()

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/caches/resolve/MultiplatformAnalysisTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/caches/resolve/MultiplatformAnalysisTestGenerated.java
@@ -23,15 +23,16 @@ public class MultiplatformAnalysisTestGenerated extends AbstractMultiplatformAna
         KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
     }
 
+    // Paritialy moved to HMPP E2E test, need to FIXME
     @TestMetadata("aliasesTypeMismatch")
     public void testAliasesTypeMismatch() throws Exception {
         runTest("testData/multiplatform/aliasesTypeMismatch/");
     }
-
-    @TestMetadata("builtinsAndStdlib")
-    public void testBuiltinsAndStdlib() throws Exception {
-        runTest("testData/multiplatform/builtinsAndStdlib/");
-    }
+    // Move to HMPP E2E test
+    //@TestMetadata("builtinsAndStdlib")
+    //public void testBuiltinsAndStdlib() throws Exception {
+    //    runTest("testData/multiplatform/builtinsAndStdlib/");
+    //}
 
     @TestMetadata("callableReferences")
     public void testCallableReferences() throws Exception {
@@ -43,20 +44,24 @@ public class MultiplatformAnalysisTestGenerated extends AbstractMultiplatformAna
         runTest("testData/multiplatform/chainedTypeAliasRefinement/");
     }
 
-    @TestMetadata("commonSealedWithPlatformInheritor")
-    public void testCommonSealedWithPlatformInheritor() throws Exception {
-        runTest("testData/multiplatform/commonSealedWithPlatformInheritor/");
-    }
+    // Move to HMPP E2E test
+    //@TestMetadata("commonSealedWithPlatformInheritor")
+    //public void testCommonSealedWithPlatformInheritor() throws Exception {
+    //    runTest("testData/multiplatform/commonSealedWithPlatformInheritor/");
+    //}
 
-    @TestMetadata("constructorsOfExpect")
-    public void testConstructorsOfExpect() throws Exception {
-        runTest("testData/multiplatform/constructorsOfExpect/");
-    }
 
-    @TestMetadata("correctOverloadResolutionAmbiguity")
-    public void testCorrectOverloadResolutionAmbiguity() throws Exception {
-        runTest("testData/multiplatform/correctOverloadResolutionAmbiguity/");
-    }
+    // Move to HMPP E2E test
+    //@TestMetadata("constructorsOfExpect")
+    //public void testConstructorsOfExpect() throws Exception {
+    //    runTest("testData/multiplatform/constructorsOfExpect/");
+    //}
+
+    // Move to HMPP E2E test
+    //@TestMetadata("correctOverloadResolutionAmbiguity")
+    //public void testCorrectOverloadResolutionAmbiguity() throws Exception {
+    //    runTest("testData/multiplatform/correctOverloadResolutionAmbiguity/");
+    //}
 
     @TestMetadata("defaultArguments")
     public void testDefaultArguments() throws Exception {
@@ -258,10 +263,12 @@ public class MultiplatformAnalysisTestGenerated extends AbstractMultiplatformAna
         runTest("testData/multiplatform/sealedInheritorsInComplexModuleStructure2/");
     }
 
-    @TestMetadata("simple")
-    public void testSimple() throws Exception {
-        runTest("testData/multiplatform/simple/");
-    }
+
+    //Already checked in MultiModulesHmpp
+    //@TestMetadata("simple")
+    //public void testSimple() throws Exception {
+    //    runTest("testData/multiplatform/simple/");
+    //}
 
     @TestMetadata("smartCastOnPropertyFromDependentModule")
     public void testSmartCastOnPropertyFromDependentModule() throws Exception {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/caches/resolve/MultiplatformAnalysisTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/caches/resolve/MultiplatformAnalysisTestGenerated.java
@@ -248,10 +248,11 @@ public class MultiplatformAnalysisTestGenerated extends AbstractMultiplatformAna
         runTest("testData/multiplatform/qualifiedReceiver/");
     }
 
-    @TestMetadata("recursiveTypes")
-    public void testRecursiveTypes() throws Exception {
-        runTest("testData/multiplatform/recursiveTypes/");
-    }
+    //Test moved to HMPP E2E
+    //@TestMetadata("recursiveTypes")
+    //public void testRecursiveTypes() throws Exception {
+    //    runTest("testData/multiplatform/recursiveTypes/");
+    //}
 
     @TestMetadata("sealedInheritorsInComplexModuleStructure1")
     public void testSealedInheritorsInComplexModuleStructure1() throws Exception {

--- a/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/build.gradle
+++ b/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/build.gradle
@@ -102,6 +102,21 @@ kotlin {
         commonTest {
             dependencies {}
         }
+        common {
+            dependencies {
+                api project(":api-jvm")
+            }
+        }
+        jvmLibrary{
+            dependsOn commonMain
+        }
+        jvm {
+            dependsOn common
+            dependencies {
+                api project(":api-jvm")
+                api project(":bottom-mpp")
+            }
+        }
 
         // intermediate between commonMain and jsJvm18Main
         kt27816Main {

--- a/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/common/common.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/common/common.kt
@@ -42,15 +42,49 @@ fun test_1(b: Base) = <!NO_ELSE_IN_WHEN{JVM}!>when<!> (b) {
 }
 
 //Test constructisOfExpect
-expect class <!LINE_MARKER("descr='Has actuals in jvm module'")!>A<!> {
+expect class <!LINE_MARKER("descr='Has actuals in jvm module'")!>constructisOfExpect<!> {
     fun <!LINE_MARKER("descr='Has actuals in jvm module'")!>commonMember<!>()
 }
 
 //Test correctOverloadResultionAmbiguity
 // KT-34027
-expect interface <!LINE_MARKER("descr='Has actuals in jsMain module'")!>A<!><T> {
+expect interface <!LINE_MARKER("descr='Has actuals in jsMain module'")!>correctOverloadResultionAmbiguity<!><T> {
     fun <!LINE_MARKER("descr='Has actuals in jsMain module'")!>foo<!>(x: T)
 }
 
-fun bar(): A<String> = null!!
+fun bar(): correctOverloadResultionAmbiguity<String> = null!!
+
+
+//Test recursiveTypes
+expect interface <!LINE_MARKER("descr='Has actuals in jvm module'"), LINE_MARKER("descr='Is subclassed by B  Click or press ... to navigate'")!>recursiveTypes<!><T : recursiveTypes<T>> {
+    fun <!LINE_MARKER("descr='Has actuals in jvm module'")!>foo<!>(): T
+}
+
+interface B : recursiveTypes<B>
+
+fun test(a: recursiveTypes<*>) {
+    a.foo()
+    a.foo().foo()
+}
+
+fun test(b: B) {
+    b.foo()
+    b.foo().foo()
+}
+
+
+//Test overrideExpect
+expect class <!LINE_MARKER("descr='Has actuals in jvm module'")!>Expect<!>
+
+interface <!LINE_MARKER("descr='Is implemented by Derived  Click or press ... to navigate'")!>Base<!> {
+    fun <!LINE_MARKER("descr='Is implemented in Derived'")!>expectInReturnType<!>(): Expect
+
+    fun expectInArgument(e: Expect)
+
+    fun Expect.expectInReceiver()
+
+    val <!LINE_MARKER("descr='Is implemented in Derived'")!>expectVal<!>: Expect
+
+    var <!LINE_MARKER("descr='Is implemented in Derived'")!>expectVar<!>: Expect
+}
 

--- a/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/common/common.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/common/common.kt
@@ -1,0 +1,56 @@
+@file:Suppress("UNUSED_PARAMETER")
+
+
+
+
+// !DIAGNOSTICS: -UNUSED_VARIABLE
+
+
+// TEST builtinsAndStdlib
+import kotlin.reflect.KCallable
+
+fun some() {
+    val string: String = ""
+    val any: Any = ""
+    val callableRef: KCallable<*> = ::commonFun
+    callableRef.name
+    // should be unresolved
+    callableRef.<!UNRESOLVED_REFERENCE!>call<!>()
+}
+
+fun commonFun() {
+}
+
+
+//Partitially test AliasesTypeMismatch
+expect open class <!LINE_MARKER("descr='Has actuals in jvm module'")!>MyCancelException<!> : MyIllegalStateException
+
+fun cancel(cause: MyCancelException) {}
+
+expect open class <!LINE_MARKER("descr='Has actuals in jvm module'")!>OtherException<!> : MyIllegalStateException
+
+fun other(cause: OtherException) {}
+
+
+//Test commonSealedWithPlatformInheritor
+sealed class <!LINE_MARKER("descr='Is subclassed by Derived PlatfromDerived  Click or press ... to navigate'")!>Base<!>
+
+class Derived : Base()
+
+fun test_1(b: Base) = <!NO_ELSE_IN_WHEN{JVM}!>when<!> (b) {
+    is Derived -> 1
+}
+
+//Test constructisOfExpect
+expect class <!LINE_MARKER("descr='Has actuals in jvm module'")!>A<!> {
+    fun <!LINE_MARKER("descr='Has actuals in jvm module'")!>commonMember<!>()
+}
+
+//Test correctOverloadResultionAmbiguity
+// KT-34027
+expect interface <!LINE_MARKER("descr='Has actuals in jsMain module'")!>A<!><T> {
+    fun <!LINE_MARKER("descr='Has actuals in jsMain module'")!>foo<!>(x: T)
+}
+
+fun bar(): A<String> = null!!
+

--- a/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/commonMain/kotlin/transitiveStory/bottomActual/mppBeginning/BottomActualDeclarations.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/commonMain/kotlin/transitiveStory/bottomActual/mppBeginning/BottomActualDeclarations.kt
@@ -2,13 +2,13 @@ package transitiveStory.bottomActual.mppBeginning
 
 val moduleName = "top-mpp"
 val commonInt = 42
-expect val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.dummyiOSMain, multimod-hmpp-top-mpp, top-mpp, multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain] module'")!>sourceSetName<!>: String
+expect val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.dummyiOSMain, multimod-hmpp-top-mpp, top-mpp, multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jvmLibrary] module'")!>sourceSetName<!>: String
 
-expect open class <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'"), LINE_MARKER("descr='Has subclasses'")!>BottomActualDeclarations<!>() {
-    val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'")!>simpleVal<!>: Int
+expect open class <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'"), LINE_MARKER("descr='Has subclasses'")!>BottomActualDeclarations<!>() {
+    val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'")!>simpleVal<!>: Int
 
-    companion object <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'")!>Compainon<!> {
-        val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'")!>inTheCompanionOfBottomActualDeclarations<!>: String
+    companion object <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'")!>Compainon<!> {
+        val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'")!>inTheCompanionOfBottomActualDeclarations<!>: String
     }
 }
 
@@ -38,12 +38,12 @@ open class <!LINE_MARKER("descr='Is subclassed by ChildOfCommonInMacos ChildOfCo
 }
 
 // has a child in jsJvm18Main
-expect open class <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'"), LINE_MARKER("descr='Is subclassed by ChildOfMPOuterInMacos ChildOfMPOuterInShared  Click or press ... to navigate'")!>MPOuter<!> {
-    protected open val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'")!>b<!>: Int
-    internal val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'")!>c<!>: Int
-    val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'")!>d<!>: Int // public by default
+expect open class <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'"), LINE_MARKER("descr='Is subclassed by ChildOfMPOuterInMacos ChildOfMPOuterInShared  Click or press ... to navigate'")!>MPOuter<!> {
+    protected open val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'")!>b<!>: Int
+    internal val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'")!>c<!>: Int
+    val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'")!>d<!>: Int // public by default
 
-    protected class <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'")!>MPNested<!> {
-        public val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain] module'")!>e<!>: Int
+    protected class <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'")!>MPNested<!> {
+        public val <!LINE_MARKER("descr='Has actuals in [multimod-hmpp.top-mpp.linuxMain, multimod-hmpp.top-mpp.macosMain, multimod-hmpp.top-mpp.jsJvm18iOSMain, multimod-hmpp.top-mpp.jvmLibrary] module'")!>e<!>: Int
     }
 }

--- a/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jsMain/kotlin/transitiveStory/bottomActual/mppBeginning/sourceSetName.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jsMain/kotlin/transitiveStory/bottomActual/mppBeginning/sourceSetName.kt
@@ -1,3 +1,15 @@
 package transitiveStory.bottomActual.mppBeginning
 
 actual val <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>sourceSetName<!>: String = "jsMain"
+
+
+fun jsFun() {
+}
+
+fun test() {
+    val <!HIGHLIGHTING("severity='WARNING'; descr='[UNUSED_VARIABLE] Variable 'string' is never used'")!>string<!>: String = ""
+    val ref: kotlin.reflect.KCallable<*> = ::jsFun
+    ref.name
+    // should be unresolved
+    ref.<!HIGHLIGHTING("severity='ERROR'; descr='[UNRESOLVED_REFERENCE] Unresolved reference: call'")!>call<!>()
+}

--- a/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jvm/jvm.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jvm/jvm.kt
@@ -1,0 +1,61 @@
+actual typealias <!LINE_MARKER("descr='Has expects in common module'")!>MyCancelException<!> = platform.lib.MyCancellationException
+
+actual open class <!LINE_MARKER("descr='Has expects in common module'")!>OtherException<!> : platform.lib.MyIllegalStateException()
+
+fun test() {
+    cancel(MyCancelException()) // TYPE_MISMATCH
+
+    other(OtherException())
+}
+
+import kotlin.reflect.KAnnotatedElement
+import kotlin.reflect.KCallable
+import <!PLATFORM_CLASS_MAPPED_TO_KOTLIN!>java.lang.Cloneable<!>
+
+fun foo(x: KAnnotatedElement): Boolean = true
+
+class Foo {
+    fun bar(a: Int, b: Int): KCallable<*> { TODO() }
+}
+
+fun jvmFun() {
+}
+
+// TEST builtinsAndStdlib
+fun getKCallable(): KCallable<*> = ::jvmFun
+
+fun <!LINE_MARKER!>main<!>() {
+    val ref = ::jvmFun
+    val typedRef: KCallable<*> = getKCallable()
+    ref.call()
+    typedRef.call()
+    foo(Foo::bar)
+}
+//Test commonSealedWithPlatformInheritor
+class PlatfromDerived : <!SEALED_INHERITOR_IN_DIFFERENT_MODULE!>Base<!>() // must be an error
+
+fun test_2(b: Base) = when (b) {
+    is Derived -> 1
+}
+
+//Test constructorsOfExpect
+actual class <!LINE_MARKER("descr='Has expects in common module'")!>A<!> {
+    actual fun <!LINE_MARKER("descr='Has expects in common module'")!>commonMember<!>() { }
+
+    fun platformMember() { }
+}
+
+fun test() {
+    A().commonMember()
+    A().platformMember()
+}
+
+//Test correctOverloadResiltionAmbiguity
+actual interface <!LINE_MARKER("descr='Has expects in common module'")!>A<!><T> {
+    actual fun <!LINE_MARKER("descr='Has expects in common module'")!>foo<!>(x: T)
+    fun foo(x: String)
+}
+
+fun main() {
+    bar().<!OVERLOAD_RESOLUTION_AMBIGUITY!>foo<!>("")
+}

--- a/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jvm/jvm.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jvm/jvm.kt
@@ -1,3 +1,4 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 actual typealias <!LINE_MARKER("descr='Has expects in common module'")!>MyCancelException<!> = platform.lib.MyCancellationException
 
 actual open class <!LINE_MARKER("descr='Has expects in common module'")!>OtherException<!> : platform.lib.MyIllegalStateException()
@@ -39,23 +40,62 @@ fun test_2(b: Base) = when (b) {
 }
 
 //Test constructorsOfExpect
-actual class <!LINE_MARKER("descr='Has expects in common module'")!>A<!> {
+actual class <!LINE_MARKER("descr='Has expects in common module'")!>constructorsOfExpect<!> {
     actual fun <!LINE_MARKER("descr='Has expects in common module'")!>commonMember<!>() { }
 
     fun platformMember() { }
 }
 
 fun test() {
-    A().commonMember()
-    A().platformMember()
+    constructorsOfExpect().commonMember()
+    constructorsOfExpect().platformMember()
 }
 
 //Test correctOverloadResiltionAmbiguity
-actual interface <!LINE_MARKER("descr='Has expects in common module'")!>A<!><T> {
+actual interface <!LINE_MARKER("descr='Has expects in common module'")!>correctOverloadResiltionAmbiguity<!><T> {
     actual fun <!LINE_MARKER("descr='Has expects in common module'")!>foo<!>(x: T)
     fun foo(x: String)
 }
 
 fun main() {
     bar().<!OVERLOAD_RESOLUTION_AMBIGUITY!>foo<!>("")
+}
+
+
+//Test recursiveTypes
+actual interface <!LINE_MARKER("descr='Has expects in common module'")!>recursiveTypes<!><T : recursiveTypes<T>> {
+    actual fun <!LINE_MARKER("descr='Has expects in common module'")!>foo<!>(): T
+    fun bar() : T
+}
+
+fun test_1(a: recursiveTypes<*>) {
+    a.foo()
+    a.bar()
+    a.foo().foo()
+    a.bar().bar()
+    a.foo().bar()
+    a.bar().foo()
+}
+
+fun test_2(b: B) {
+    b.foo()
+    b.bar()
+    b.foo().foo()
+    b.bar().bar()
+    b.foo().bar()
+    b.bar().foo()
+}
+//Test overrideExpect
+actual typealias <!LINE_MARKER("descr='Has expects in common module'")!>Expect<!> = String
+
+interface Derived : Base {
+    override fun <!LINE_MARKER("descr='Overrides function in 'Base''")!>expectInReturnType<!>(): Expect
+
+    override fun <!LINE_MARKER("descr='Overrides function in 'Base''")!>expectInArgument<!>(e: Expect)
+
+    override fun Expect.<!LINE_MARKER("descr='Overrides function in 'Base''")!>expectInReceiver<!>()
+
+    override val <!LINE_MARKER("descr='Overrides property in 'Base''")!>expectVal<!>: Expect
+
+    override var <!LINE_MARKER("descr='Overrides property in 'Base''")!>expectVar<!>: Expect
 }

--- a/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jvmLibrary/kotlin/transitiveStory/bottomActual/mppBeginning/BottomActualDeclarations.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jvmLibrary/kotlin/transitiveStory/bottomActual/mppBeginning/BottomActualDeclarations.kt
@@ -1,0 +1,12 @@
+package transitiveStory.bottomActual.mppBeginning
+
+actual open class <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>BottomActualDeclarations<!> {
+    actual val <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>simpleVal<!>: Int = commonInt
+
+    actual companion object <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>Compainon<!> {
+        actual val <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>inTheCompanionOfBottomActualDeclarations<!>: String =
+            "I'm a string from the companion object of `$this` in `$sourceSetName` module `$moduleName`"
+    }
+}
+
+actual val <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>sourceSetName<!>: String = "jvmLibrary"

--- a/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jvmLibrary/kotlin/transitiveStory/bottomActual/mppBeginning/MPOuter.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/hmppImportAndHighlighting/multiModulesHmpp/top-mpp/src/jvmLibrary/kotlin/transitiveStory/bottomActual/mppBeginning/MPOuter.kt
@@ -1,0 +1,11 @@
+package transitiveStory.bottomActual.mppBeginning
+
+actual open class <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>MPOuter<!> {
+    protected actual open val <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>b<!>: Int = 65
+    internal actual val <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>c<!>: Int = 235
+    actual val <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>d<!>: Int = 235
+
+     protected actual class <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>MPNested<!> {
+        actual val <!LINE_MARKER("descr='Has expects in multimod-hmpp.top-mpp.commonMain module'")!>e<!>: Int = 2452
+    }
+}


### PR DESCRIPTION
1) Added HierarchicalMultiplatformProjectImportTest.kt
2) Added a few modules in HmppImportAndHighlightingTests.kt test data
3) Moved a few autotests from MPAnalysis in new modules in HMPP E2E.

Базовая идея решения:
Избавиться от MPAnalysis тестов, путем их переноса в HMPP E2E тесты, часть тестов перенесена, часть тестов удалена, т.к. дублируются. Зарефакторить и разделить на более внятные конфигурации HMPPImport и HMPP E2E, разместить перенесенные тесты из MPAnalysis по конфигурациям. Найти способ, как явно учитывать front проверки в E2E, мб посмотреть в сторону параметризации входных данных.

Плюсы такого подхода:
1) Не нужно помнить про запуск отдельных тестов на проверка фронтенда. Этого файла не будет. Скорее всего можно захватить и файл с проверкой Highlighting.
2) Все фронтовые тесты будут запускаться на разных версиях плагина.
3) Время прогона E2E тестов почти не увеличилось.

Минусы подхода:
1) Сейчас непонятно какие фронтовые проверки запустились.


Проблемы:
1) Пока мешанина в тестовых конфигурациях и зависимостях, я уверен, что что-то напутал в gradle.build конфиге. Нужно описать конечное кол-во конфигураций, которые покроют все тесты и фронтовые, и Import, и E2E и разложить тесты по конфигурациям.
2) Нужно решить проблему с отображением запущенных фронтовых тестов, хочется видеть явно какие проверки пройдены.
3) Почему-то на KotlinGradlePlugin-1.5.31 стреляет ошибка java.lang.AssertionError: Listeners leaked for interface com.intellij.openapi.editor.event.DocumentListener


Идея с написанием своего DSL (Baseline solution) мне не понравилась, потому что тем самым мы:
1) Добавим лишние уровни абстракции, увеличим энтропию и усложним код.
2) Будем дублировать все проверки, вместо того, чтобы максимально сократить дубликаты.
